### PR TITLE
Ignore intermediate files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+tmp/
+node_modules/


### PR DESCRIPTION
Adds a .gitignore to skip the intermediate files, like node_modules/ and tmp/
