### PR TITLE
Bump the version of jsdom

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "jsdom": "~0.2.14",
+    "jsdom": "~0.3.0",
     "htmlparser": "1.7.6",
     "xmlhttprequest": "~1.4.2",
     "location": "0.0.1",


### PR DESCRIPTION
I had issues installing the module because of the version of contexify used in the version of jsdom that the module requires.

This pull request bumps the jsdom version up and I've confirmed that I can correctly install the module now and that tests pass with `grunt test`.
