### PR TITLE
update README.md with note about jsdom version restrictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,11 @@ How to use jQuery >= 2.x in Node.js >= 0.10
 
 ```bash
 npm install -S 'jquery@>=2.1'
-npm install -S 'jsdom@latest'
+npm install -S 'jsdom@3.1.2'
 ```
+
+(Note that version 3.1.2 of jsdom is required, because as of jsdom version 4.0.0, jsdom no longer works
+with Node.js.  If you use Io.js rather than Node.js, you can use the latest 4.x release of jsdom.)
 
 `testjq.js`:
 ```javascript


### PR DESCRIPTION
Hi.  I'm hoping you'll consider accepting this change (or something like it) to this README.  I found this README extremely helpful, but I discovered that these steps no longer work exactly as stated with Node.js because the latest version of jsdom doesn't work with Node.js (a fact that is documented here: https://www.npmjs.com/package/jsdom).  Installing an older version of jsdom fixes the problem, so I'm proposing to change the README accordingly.
